### PR TITLE
Transforms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,6 @@ members = [
   "birb_utils",
   "birb_window",
   "birb_winit",
-  "birb_registry"
+  "birb_registry",
+  "birb_transform",
 ]

--- a/birb_examples/Cargo.toml
+++ b/birb_examples/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 birb = { version = "0.1.0", path = "../birb" }
 birb_maths = { version = "0.1.0", path = "../birb_maths" }
+birb_transform = { version = "0.1.0", path = "../birb_transform" }
 birb_utils = { version = "0.1.0", path = "../birb_utils" }
 birb_window = { version = "0.1.0", path = "../birb_window" }
 birb_winit = { version = "0.1.0", path = "../birb_winit" }

--- a/birb_examples/examples/birb.rs
+++ b/birb_examples/examples/birb.rs
@@ -18,7 +18,7 @@ impl Module for BirbSystem {
     fn tick(&mut self, app: &App) {
         let gravity = app.get_module::<Gravity>().unwrap().gravity;
         let delta = app.get_module::<Clock>().unwrap().delta();
-        app.get_entity_mut::<Birb>()
+        app.get_entities_mut::<Birb>()
             .unwrap()
             .par_iter_mut()
             .for_each(|birb| {
@@ -62,7 +62,11 @@ pub fn main() {
 
     println!(
         "Fell to: {:?}",
-        app.get_entity::<Birb>().unwrap().first().unwrap().position
+        app.get_entities::<Birb>()
+            .unwrap()
+            .first()
+            .unwrap()
+            .position
     );
 
     println!(

--- a/birb_examples/examples/transform.rs
+++ b/birb_examples/examples/transform.rs
@@ -1,0 +1,42 @@
+use birb::{App, Module, TypedEntityID};
+use birb_maths::two::*;
+use birb_transform::Transform;
+use birb_utils::time::Clock;
+
+pub struct Square {
+    width: f32,
+    height: f32,
+    transform: TypedEntityID<Transform<f32>>,
+}
+
+#[derive(Debug)]
+pub struct Spinner {
+    velocity: f32,
+}
+
+impl Module for Spinner {
+    fn tick(&mut self, app: &App) {
+        let squares = app.get_entities_mut::<Square>().unwrap();
+        let delta = app.get_module::<Clock>().unwrap().delta();
+        let rotation = Rotor::from_angle(self.velocity * delta.as_secs_f32());
+
+        for square in squares.iter() {
+            let mut transform = app.get_entity_mut(square.transform).unwrap();
+            transform.rotation *= rotation;
+            println!("{:?}", transform.rotation);
+        }
+    }
+}
+
+pub fn main() {
+    let mut app = App::new();
+    app.register(Clock::register);
+    app.register_module(Spinner { velocity: 1.0 });
+    let transform = app.register_entity(Transform::identity(None));
+    app.register_entity(Square {
+        width: 1.0,
+        height: 1.0,
+        transform,
+    });
+    app.run();
+}

--- a/birb_maths/src/lib.rs
+++ b/birb_maths/src/lib.rs
@@ -3,3 +3,153 @@
 #![warn(clippy::nursery)]
 
 pub mod two;
+
+pub trait Zero {
+    fn zero() -> Self;
+}
+
+pub trait Unit {
+    fn unit() -> Self;
+}
+
+impl Zero for u8 {
+    fn zero() -> Self {
+        0
+    }
+}
+
+impl Zero for u16 {
+    fn zero() -> Self {
+        0
+    }
+}
+
+impl Zero for u32 {
+    fn zero() -> Self {
+        0
+    }
+}
+
+impl Zero for u64 {
+    fn zero() -> Self {
+        0
+    }
+}
+
+impl Zero for usize {
+    fn zero() -> Self {
+        0
+    }
+}
+
+impl Zero for i8 {
+    fn zero() -> Self {
+        0
+    }
+}
+
+impl Zero for i16 {
+    fn zero() -> Self {
+        0
+    }
+}
+
+impl Zero for i32 {
+    fn zero() -> Self {
+        0
+    }
+}
+
+impl Zero for i64 {
+    fn zero() -> Self {
+        0
+    }
+}
+
+impl Zero for isize {
+    fn zero() -> Self {
+        0
+    }
+}
+
+impl Zero for f32 {
+    fn zero() -> Self {
+        0.0
+    }
+}
+
+impl Zero for f64 {
+    fn zero() -> Self {
+        0.0
+    }
+}
+
+impl Unit for u8 {
+    fn unit() -> Self {
+        1
+    }
+}
+
+impl Unit for u16 {
+    fn unit() -> Self {
+        1
+    }
+}
+impl Unit for u32 {
+    fn unit() -> Self {
+        1
+    }
+}
+
+impl Unit for u64 {
+    fn unit() -> Self {
+        1
+    }
+}
+
+impl Unit for usize {
+    fn unit() -> Self {
+        1
+    }
+}
+
+impl Unit for i8 {
+    fn unit() -> Self {
+        1
+    }
+}
+
+impl Unit for i16 {
+    fn unit() -> Self {
+        1
+    }
+}
+impl Unit for i32 {
+    fn unit() -> Self {
+        1
+    }
+}
+
+impl Unit for i64 {
+    fn unit() -> Self {
+        1
+    }
+}
+
+impl Unit for isize {
+    fn unit() -> Self {
+        1
+    }
+}
+
+impl Unit for f32 {
+    fn unit() -> Self {
+        1.0
+    }
+}
+
+impl Unit for f64 {
+    fn unit() -> Self {
+        1.0
+    }
+}

--- a/birb_transform/Cargo.toml
+++ b/birb_transform/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "birb_transform"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+birb = { version = "0.1.0", path = "../birb" }
+birb_maths = { version = "0.1.0", path = "../birb_maths" }
+parking_lot = "0.12.1"

--- a/birb_transform/src/lib.rs
+++ b/birb_transform/src/lib.rs
@@ -1,0 +1,47 @@
+#![deny(clippy::all)]
+#![warn(clippy::pedantic)]
+#![warn(clippy::nursery)]
+
+use birb::{App, TypedEntityID};
+#[allow(clippy::wildcard_imports)]
+use birb_maths::two::*;
+use parking_lot::{MappedRwLockReadGuard, MappedRwLockWriteGuard};
+
+#[derive(Clone, Debug)]
+pub struct Transform<T> {
+    pub translation: Vector<T>,
+    pub rotation: Rotor<T>,
+    pub scale: Vector<T>,
+    parent: Option<TypedEntityID<Transform<T>>>,
+}
+
+impl<T: 'static + Copy + Send + Sync> Transform<T> {
+    pub const fn new(
+        translation: Vector<T>,
+        rotation: Rotor<T>,
+        scale: Vector<T>,
+        parent: Option<TypedEntityID<Self>>,
+    ) -> Self {
+        Self {
+            translation,
+            rotation,
+            scale,
+            parent,
+        }
+    }
+
+    pub fn get_parent<'a>(&'a self, app: &'a App) -> Option<MappedRwLockReadGuard<'a, Self>> {
+        app.get_entity(self.parent?)
+    }
+
+    pub fn get_parent_mut<'a>(&'a self, app: &'a App) -> Option<MappedRwLockWriteGuard<'a, Self>> {
+        app.get_entity_mut(self.parent?)
+    }
+}
+
+impl<T: 'static + Unit + Zero + Copy + Send + Sync> Transform<T> {
+    #[must_use]
+    pub fn identity(parent: Option<TypedEntityID<Self>>) -> Self {
+        Self::new(Vector::zero(), Rotor::identity(), Vector::one(), parent)
+    }
+}


### PR DESCRIPTION
Adds 2D transforms, due to their parent-child relationships, I decided to make transforms entities, meaning parents can be stored as entity IDs (also something I added in this branch). Entity IDs are unique IDs assigned to each entity, they're also unique across archetypes, so even a Transform and a Player entity won't share an ID. IDs can be stored in two formats, a typed entity ID which keeps track of the archetype as well as storing the ID, meaning you can require a specific type of entity, as done in the Transform type. There's also an untyped entity ID which just stores the ID with no type information, so you have to specify the type when getting the entity. This also renames and adds some base app methods

get_entity -> get_entities
get_entity_mut -> get_entities_mut
register_entity - now returns a TypedEntityID
get_entity - new function that takes a TypedEntityID and spits out a reference to that entity
get_entity_mut - new function that takes a TypedEntityID and spits out a mutable reference to that entity
get_entity_untyped - new function that takes a UntypedEntityID and spits out a reference to that entity
get_entity_untyped_mut - new function that takes a UntypedEntityID and spits out a mutable reference to that entity

I'm yet to benchmark the system of transforms as entities, and there are a couple things I'd like to do before merging, but I've made a lot of changes and I think a review would be good before moving forwards